### PR TITLE
remove: SpringSaveCache command and references

### DIFF
--- a/doc/telescope-spring.txt
+++ b/doc/telescope-spring.txt
@@ -136,7 +136,6 @@ Alternative Commands:~
     :SpringPatchMapping   " Find all PATCH endpoints
 
 Cache Management Commands:~
-    :Spring SaveCache     " Force save cache to disk (persistent mode)
     :Spring ClearCache    " Clear all cached data
     :Spring CacheStatus   " Show detailed cache information
 
@@ -398,11 +397,9 @@ Features:
   • 🗂️ Cache location: `~/.local/share/nvim/telescope-spring/[project-name]/`
 
 Cache Management Commands:~
-    :SpringSaveCache      Force save current cache to disk
     :SpringClearCache     Clear all cache files for current project
     :SpringCacheStatus    Show detailed cache information
     
-    :Spring SaveCache     Same as :SpringSaveCache
     :Spring ClearCache    Same as :SpringClearCache  
     :Spring CacheStatus   Same as :SpringCacheStatus
 

--- a/plugin/spring.lua
+++ b/plugin/spring.lua
@@ -25,12 +25,6 @@ vim.api.nvim_create_user_command("SpringPatchMapping", function()
 end, {})
 
 -- Cache management commands
-vim.api.nvim_create_user_command("SpringSaveCache", function()
-  local cache = require "spring.cache"
-  cache.save_to_file()
-  vim.notify("Spring cache saved to disk", vim.log.levels.INFO)
-end, {})
-
 vim.api.nvim_create_user_command("SpringClearCache", function()
   local cache = require "spring.cache"
   cache.clear_persistent_cache()
@@ -47,7 +41,7 @@ vim.api.nvim_create_user_command("Spring", function(opts)
   local spring = require "spring"
   local subcommand = opts.fargs[1]
   if not subcommand then
-    vim.notify("Usage: Spring {Get|Post|Put|Delete|Patch|SaveCache|ClearCache|CacheStatus}", vim.log.levels.WARN)
+    vim.notify("Usage: Spring {Get|Post|Put|Delete|Patch|ClearCache|CacheStatus}", vim.log.levels.WARN)
     return
   end
 
@@ -64,10 +58,6 @@ vim.api.nvim_create_user_command("Spring", function(opts)
     spring.pick_delete_mapping(config.delete or {})
   elseif method == "PATCH" then
     spring.pick_patch_mapping(config.patch or {})
-  elseif method == "SAVECACHE" then
-    local cache = require "spring.cache"
-    cache.save_to_file()
-    vim.notify("Spring cache saved to disk", vim.log.levels.INFO)
   elseif method == "CLEARCACHE" then
     local cache = require "spring.cache"
     cache.clear_persistent_cache()
@@ -79,13 +69,13 @@ vim.api.nvim_create_user_command("Spring", function(opts)
     vim.notify(
       "Unknown method: "
         .. subcommand
-        .. ". Available: Get, Post, Put, Delete, Patch, SaveCache, ClearCache, CacheStatus",
+        .. ". Available: Get, Post, Put, Delete, Patch, ClearCache, CacheStatus",
       vim.log.levels.ERROR
     )
   end
 end, {
   nargs = 1,
   complete = function()
-    return { "Get", "Post", "Put", "Delete", "Patch", "SaveCache", "ClearCache", "CacheStatus" }
+    return { "Get", "Post", "Put", "Delete", "Patch", "ClearCache", "CacheStatus" }
   end,
 })

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,6 @@ A powerful Telescope picker for quickly finding and navigating Spring Boot API e
 ### Cache Management Commands
 
 ```vim
-:Spring SaveCache     " Manually save cache to disk (persistent mode only)
 :Spring ClearCache    " Clear all cached data
 :Spring CacheStatus   " Show current cache status
 ```
@@ -277,7 +276,6 @@ require("spring").setup({
 
 **Cache Management:**
 ```vim
-:SpringSaveCache     " Force save current cache to disk
 :SpringClearCache    " Clear all cache files for current project
 :SpringCacheStatus   " Show detailed cache information
 ```


### PR DESCRIPTION
Remove SpringSaveCache command as it doesn't align with user needs and is rarely used. This includes:
- Removed SpringSaveCache command from plugin/spring.lua
- Removed SaveCache subcommand from Spring main command
- Updated documentation and README to reflect changes